### PR TITLE
feat: add push trigger for stage branch in CI workflow

### DIFF
--- a/.github/workflows/stageBuild.yml
+++ b/.github/workflows/stageBuild.yml
@@ -1,6 +1,9 @@
 name: DevTools Frontend CI
 
 on:
+  push:
+    branches:
+      - stage
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Updated the GitHub Actions workflow to include a push trigger for the 'stage' branch. This enhancement allows for automated builds and tests to run whenever changes are pushed to the stage branch, improving the CI/CD process for the Chrome DevTools frontend.