### PR TITLE
feat: add CI workflow for building and deploying DevTools frontend

### DIFF
--- a/.github/workflows/stageBuild.yml
+++ b/.github/workflows/stageBuild.yml
@@ -1,4 +1,4 @@
-name: DevTools Frontend CI
+name: DevTools Stage Frontend CI
 
 on:
   workflow_dispatch:

--- a/.github/workflows/stageBuild.yml
+++ b/.github/workflows/stageBuild.yml
@@ -1,0 +1,82 @@
+name: DevTools Frontend CI
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build (e.g. v1, v2, v3)"
+        required: true
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    env:
+      NODE_VERSION: 22                     
+      S3_BUCKET: stage-falcon-component-v1   
+      AWS_REGION: us-east-1
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: stage
+
+      - name: Setup depot_tools
+        run: |
+          git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git /tmp/depot_tools
+          echo "$GITHUB_WORKSPACE" >> $GITHUB_PATH
+          echo "/tmp/depot_tools" >> $GITHUB_PATH
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+        
+      - name: Sync dependencies
+        run: |
+          export PATH="/tmp/depot_tools:$PATH"
+          gclient sync
+
+      - name: Generate build files
+        run: |
+          export PATH="/tmp/depot_tools:$PATH"
+          gn gen out/Default
+
+      - name: Build Chrome DevTools
+        run: |
+          export PATH="/tmp/depot_tools:$PATH"
+          npm install
+          npm run build
+
+      - name: Find DevTools build folder
+        id: find_frontend_dir
+        run: |
+            # Find the parent folder containing devtools_app.html
+            FRONTEND_DIR=$(find out -type f -name "devtools_app.html" -exec dirname {} \;)
+            echo "Detected frontend directory: $FRONTEND_DIR"
+            echo "FRONTEND_DIR=$FRONTEND_DIR" >> $GITHUB_ENV
+
+      - name: Print versions
+        run: |
+          node -v
+          npm -v
+
+      - name: List built files
+        run: ls -altr ${{ env.FRONTEND_DIR }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+            aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID_DEV }}
+            aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY_DEV }}
+            aws-region: ${{ env.AWS_REGION }}
+
+      - name: Upload front_end folder to S3
+        run: |
+          aws s3 sync ${{ env.FRONTEND_DIR }} s3://${{ env.S3_BUCKET }}/${{ inputs.version }}/ \
+          --acl public-read --follow-symlinks --delete
+
+      - name: Confirm S3 upload
+        run: aws s3 ls s3://${{ env.S3_BUCKET }}/${{ inputs.version }}/


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow for the DevTools frontend, enabling builds and deployments to an S3 bucket. The workflow includes steps for setting up the environment, syncing dependencies, generating build files, and uploading the built files to S3. It also allows for version input during the workflow dispatch.